### PR TITLE
Bumped min PHP version to 8.3

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -13,18 +13,16 @@ jobs:
       max-parallel: 3
       matrix:
         php:
-          - 8.0
-          - 8.1
-          - 8.2
           - 8.3
-        composer: 
-          - 2  
+          - 8.4
+        composer:
+          - 2
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install PHP
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, pcre
@@ -38,7 +36,7 @@ jobs:
         run: composer test
       - name: Install Composer dependencies (without dev)
         run: composer install --no-progress --no-dev --no-suggest --prefer-dist --optimize-autoloader
-        
+
   dependabot:
     needs: tests
     permissions:
@@ -69,4 +67,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}           
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Small decorator that extends Symfony OutputInterface delivered class with few options for easier to log data",
     "type": "library",
     "require": {
-        "symfony/console": "^6",
-        "php": ">=8.0.2"
+        "php": "^8.3",
+        "symfony/console": "^7"
     },
     "license": "MIT",
     "authors": [

--- a/src/OutputDecorator.php
+++ b/src/OutputDecorator.php
@@ -15,23 +15,20 @@ class OutputDecorator implements OutputInterface
     /**
      * Ident for each line in left
      *
-     * @var int
+     * @noinspection PropertyCanBePrivateInspection
      */
-    protected $indent = 0;
-
-    /**
-     * @var OutputInterface
-     */
-    protected $output;
+    protected int $indent = 0;
 
     /**
      * OutputDecorator constructor.
      *
-     * @param OutputInterface $originalOutput Output interface where this decorator will write
+     * @param OutputInterface $output Output interface where this decorator will write
+     *
+     * @noinspection PropertyCanBePrivateInspection
      */
-    public function __construct(OutputInterface $originalOutput)
-    {
-        $this->output = $originalOutput;
+    public function __construct(
+        protected readonly OutputInterface $output
+    ) {
     }
 
     /**
@@ -81,7 +78,7 @@ class OutputDecorator implements OutputInterface
     /**
      * @inheritDoc
      */
-    public function write($messages, $newline = false, $options = self::OUTPUT_NORMAL)
+    public function write(iterable|string $messages, bool $newline = false, int $options = self::OUTPUT_NORMAL): void
     {
         if ($this->indent > 0) {
             $tmpMsg = '';
@@ -90,10 +87,8 @@ class OutputDecorator implements OutputInterface
             }
             $messages = rtrim($tmpMsg);
         }
-        /*if (trim($messages) == '') {
-            return $this->output->write(var_export([$messages, debug_backtrace(false)[1]], true), $newline, $options);
-        }*/
-        return $this->output->write($messages, $newline, $options);
+
+        $this->output->write($messages, $newline, $options);
     }
 
     /**
@@ -143,7 +138,7 @@ class OutputDecorator implements OutputInterface
     /**
      * @inheritDoc
      */
-    public function writeln($messages, $options = 0)
+    public function writeln(iterable|string $messages, int $options = 0): void
     {
         $this->write($messages, true, $options);
     }
@@ -151,7 +146,7 @@ class OutputDecorator implements OutputInterface
     /**
      * @inheritDoc
      */
-    public function setVerbosity($level)
+    public function setVerbosity(int $level): void
     {
         $this->output->setVerbosity($level);
     }
@@ -199,7 +194,7 @@ class OutputDecorator implements OutputInterface
     /**
      * @inheritDoc
      */
-    public function setDecorated($decorated): void
+    public function setDecorated(bool $decorated): void
     {
         $this->output->setDecorated($decorated);
     }

--- a/tests/OutputDecoratorTest.php
+++ b/tests/OutputDecoratorTest.php
@@ -7,14 +7,8 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class OutputDecoratorTest extends TestCase
 {
-    /**
-     * @var OutputDecorator
-     */
-    protected $decorator;
-    /**
-     * @var BufferedOutput
-     */
-    protected $output;
+    protected OutputDecorator $decorator;
+    protected BufferedOutput $output;
 
     protected function setUp(): void
     {
@@ -93,13 +87,12 @@ class OutputDecoratorTest extends TestCase
         ];
     }
 
-    protected function useDecoratorMethod(string $method, string $text, array $params): string {
+    private function useDecoratorMethod(string $method, string $text, array $params): string {
         if (empty($params)) {
             $this->decorator->$method($text);
         } else {
-            $args = $params;
-            array_unshift($args, $text);
-            call_user_func_array([$this->decorator, $method], $args);
+            $args = [$text, ...$params];
+            $this->decorator->$method(...$args);
         }
 
         return $this->output->fetch();
@@ -108,7 +101,7 @@ class OutputDecoratorTest extends TestCase
     /**
      * @dataProvider getTestData
      */
-    public function testIncrIndent(string $method, string $text, array $args = [], $shouldReturn = null): void {
+    public function testIncrIndent(string $method, string $text, array $args = [], ?string $shouldReturn = null): void {
         if ($shouldReturn === null) {
             $shouldReturn = $text;
         }
@@ -130,7 +123,7 @@ class OutputDecoratorTest extends TestCase
     /**
      * @dataProvider getTestData
      */
-    public function testDecrIndent(string $method, string $text, array $args = [], $shouldReturn = null): void
+    public function testDecrIndent(string $method, string $text, array $args = [], ?string $shouldReturn = null): void
     {
         if ($shouldReturn === null) {
             $shouldReturn = $text;
@@ -149,7 +142,7 @@ class OutputDecoratorTest extends TestCase
     /**
      * @dataProvider getTestData
      */
-    public function testResetIncr(string $method, string $text, array $args = [], $shouldReturn = null): void {
+    public function testResetIncr(string $method, string $text, array $args = [], ?string $shouldReturn = null): void {
         if ($shouldReturn === null) {
             $shouldReturn = $text;
         }


### PR DESCRIPTION
Resolves #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP version support to 8.3 and above.
  * Increased minimum required Symfony Console version to 7.
  * Improved type safety and modernized code with explicit type hints and typed properties.
  * Updated GitHub Actions workflow to test only PHP 8.3 and 8.4.
* **Tests**
  * Enhanced test code with typed properties and updated method signatures for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->